### PR TITLE
Implement airgap image list command for Windows

### DIFF
--- a/.github/workflows/win-wsl.yaml
+++ b/.github/workflows/win-wsl.yaml
@@ -135,6 +135,14 @@ jobs:
           pattern: k0s-{linux,windows}-amd64
           merge-multiple: true
 
+      # Test that the airgap list has expected number of entries on Windows
+      - name: Airgap image list
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          $count = (./k0s.exe airgap list-images | Measure-Object -Line).Lines
+          if ($count -ne 4) { throw "Expected 4 airgap images, got $count" }
       - name: Install and start k0s controller
         id: start-controller
         run: |

--- a/cmd/airgap/listimages_test.go
+++ b/cmd/airgap/listimages_test.go
@@ -1,23 +1,18 @@
+//go:build !windows
+
 // SPDX-FileCopyrightText: 2021 k0s authors
 // SPDX-License-Identifier: Apache-2.0
 
 package airgap_test
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
-	"testing/iotest"
 
-	"github.com/k0sproject/k0s/cmd"
 	internalio "github.com/k0sproject/k0s/internal/io"
 	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
-
-	"github.com/spf13/cobra"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -105,17 +100,4 @@ spec:
 			})
 		}
 	})
-}
-
-func newAirgapListImagesCmdWithConfig(t *testing.T, config string, args ...string) (_ *cobra.Command, out, err *strings.Builder) {
-	configFile := filepath.Join(t.TempDir(), "k0s.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(config), 0644))
-
-	out, err = new(strings.Builder), new(strings.Builder)
-	cmd := cmd.NewRootCmd()
-	cmd.SetArgs(append([]string{"airgap", "--config=" + configFile, "list-images"}, args...))
-	cmd.SetIn(iotest.ErrReader(errors.New("unexpected read from standard input")))
-	cmd.SetOut(out)
-	cmd.SetErr(err)
-	return cmd, out, err
 }

--- a/cmd/airgap/listimages_testhelper_test.go
+++ b/cmd/airgap/listimages_testhelper_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package airgap_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/k0sproject/k0s/cmd"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newAirgapListImagesCmdWithConfig(t *testing.T, config string, args ...string) (_ *cobra.Command, out, err *strings.Builder) {
+	configFile := filepath.Join(t.TempDir(), "k0s.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(config), 0644))
+
+	out, err = new(strings.Builder), new(strings.Builder)
+	cmd := cmd.NewRootCmd()
+	cmd.SetArgs(append([]string{"airgap", "--config=" + configFile, "list-images"}, args...))
+	cmd.SetIn(iotest.ErrReader(errors.New("unexpected read from standard input")))
+	cmd.SetOut(out)
+	cmd.SetErr(err)
+	return cmd, out, err
+}

--- a/cmd/airgap/listimages_windows_test.go
+++ b/cmd/airgap/listimages_windows_test.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package airgap_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAirgapListImagesWindows(t *testing.T) {
+	defaults := v1beta1.DefaultClusterImages()
+	expectedImages := []string{
+		defaults.Windows.Pause.URI(),
+		defaults.Windows.KubeProxy.URI(),
+		defaults.Calico.Windows.CNI.URI(),
+		defaults.Calico.Windows.Node.URI(),
+	}
+
+	t.Run("DefaultConfig", func(t *testing.T) {
+		underTest, out, err := newAirgapListImagesCmdWithConfig(t, "{}")
+
+		require.NoError(t, underTest.Execute())
+		lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+
+		assert.Len(t, lines, len(expectedImages), "Expected exactly %d images", len(expectedImages))
+		for _, img := range expectedImages {
+			assert.Contains(t, lines, img)
+		}
+		assert.Empty(t, err.String())
+	})
+
+	t.Run("AllFlagIsNoOp", func(t *testing.T) {
+		underTest, out, err := newAirgapListImagesCmdWithConfig(t, "{}", "--all")
+
+		require.NoError(t, underTest.Execute())
+		lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+
+		// --all has no additional effect on Windows; same 4 images expected
+		assert.Len(t, lines, len(expectedImages), "Expected exactly %d images with --all", len(expectedImages))
+		assert.Empty(t, err.String())
+	})
+}

--- a/pkg/airgap/images.go
+++ b/pkg/airgap/images.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // SPDX-FileCopyrightText: 2021 k0s authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/airgap/images_windows.go
+++ b/pkg/airgap/images_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+// SPDX-FileCopyrightText: 2026 k0s authors
+// SPDX-License-Identifier: Apache-2.0
+
+package airgap
+
+import (
+	"github.com/k0sproject/k0s/pkg/apis/k0s/v1beta1"
+)
+
+// GetImageURIs returns all image tags for Windows worker nodes
+func GetImageURIs(spec *v1beta1.ClusterSpec, _ bool) []string {
+	return []string{
+		spec.Images.Windows.Pause.URI(),
+		spec.Images.Windows.KubeProxy.URI(),
+		spec.Images.Calico.Windows.CNI.URI(),
+		spec.Images.Calico.Windows.Node.URI(),
+	}
+}


### PR DESCRIPTION
Separated the implementations so now the command on Windows returns only the Windows images

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- check the related options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Manual test
- [ ] Auto test added

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style [guidelines](https://docs.k0sproject.io/head/contributors/) of this project
- [ ] My commit messages are [signed-off](https://docs.k0sproject.io/head/contributors/github_workflow/)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
